### PR TITLE
Fix issue with removed message

### DIFF
--- a/cron/thread-lifecycle.js
+++ b/cron/thread-lifecycle.js
@@ -61,8 +61,7 @@ module.exports = {
             try {
               lastMessage = await thread.messages.fetch(thread.lastMessageId)
             } catch (error) {
-              console.error(`Failed to fetch last message for thread ${thread.id}:`, error)
-              thread.messages.send("Failed to fetch last message.")
+              console.error(`Failed to fetch last message for thread ${thread.id}`)
               archiveThreadPrompt(client, thread)
               return
             }

--- a/cron/thread-lifecycle.js
+++ b/cron/thread-lifecycle.js
@@ -57,9 +57,15 @@ module.exports = {
         .forEach(async (channel) => {
           const threads = await channel.threads.fetch()
           threads.threads.forEach(async (thread) => {
-            const lastMessage = await thread.messages.fetch(
-              thread.lastMessageId
-            )
+            let lastMessage = null
+            try {
+              lastMessage = await thread.messages.fetch(thread.lastMessageId)
+            } catch (error) {
+              console.error(`Failed to fetch last message for thread ${thread.id}:`, error)
+              thread.messages.send("Failed to fetch last message.")
+              archiveThreadPrompt(client, thread)
+              return
+            }
 
             const lastActivity = Math.max(
               lastMessage?.createdTimestamp ?? 0,


### PR DESCRIPTION
When the last message from the thread has been removed by user, the bot will fail with:
```
DiscordAPIError: Unknown Message
    at RequestHandler.execute (/discord-bot/node_modules/discord.js/src/rest/RequestHandler.js:350:13)	
    at processTicksAndRejections (node:internal/process/task_queues:96:5)	
    at async RequestHandler.push (/discord-bot/node_modules/discord.js/src/rest/RequestHandler.js:51:14)	
    at async MessageManager._fetchId (/discord-bot/node_modules/discord.js/src/managers/MessageManager.js:219:18)	
    at async /discord-bot/cron/thread-lifecycle.js:60:33 {	
  method: 'get',	
  path: '/channels/123123123/messages/456456456',	
  code: 10008,	
  httpStatus: 404,	
  requestData: { json: undefined, files: [] }	
}
```


> This PR is tagged with v1.0.1-rc2